### PR TITLE
Hacky export with annotations fix

### DIFF
--- a/ios/RNTPTDocumentView.h
+++ b/ios/RNTPTDocumentView.h
@@ -733,6 +733,8 @@ static NSString * const PTSignaturesManager_signatureDirectory = @"PTSignaturesM
 
 - (void)showAddPagesViewFromRect:(NSDictionary *)rect;
 
+- (void)exportIdenticalCopySelected;
+
 - (void)shareCopyfromRect:(NSDictionary *)rect withFlattening:(BOOL)flattening;
 
 - (void)openThumbnailsView;

--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -3209,6 +3209,12 @@ NS_ASSUME_NONNULL_END
     [documentViewController showAddPagesViewFromScreenRect:screenRect];
 }
 
+- (void)exportIdenticalCopySelected
+{
+  PTDocumentBaseViewController *documentViewController = self.currentDocumentViewController;
+  [documentViewController exportIdenticalCopySelected];
+}
+
 - (void)shareCopyfromRect:(NSDictionary *)rect withFlattening:(BOOL)flattening
 {
     PTDocumentBaseViewController *documentViewController = self.currentDocumentViewController;

--- a/ios/RNTPTDocumentViewManager.h
+++ b/ios/RNTPTDocumentViewManager.h
@@ -191,6 +191,8 @@
 
 - (void)showAddPagesViewForDocumentViewTag:(nonnull NSNumber *)tag rect:(NSDictionary *)rect;
 
+- (void)exportIdenticalCopySelected:(nonnull NSNumber *)tag;
+
 - (void)shareCopyForDocumentViewTag:(nonnull NSNumber *)tag rect:(NSDictionary *)rect withFlattening:(BOOL)flattening;
 
 - (void)openThumbnailsViewForDocumentViewTag:(NSNumber *)tag;

--- a/ios/RNTPTDocumentViewManager.m
+++ b/ios/RNTPTDocumentViewManager.m
@@ -1598,6 +1598,12 @@ RCT_CUSTOM_VIEW_PROPERTY(signatureColors, NSArray, RNTPTDocumentView)
     }
 }
 
+- (void)exportIdenticalCopySelected:(NSNumber *)tag
+{
+  RNTPTDocumentView *documentView = self.documentViews[tag];
+  [documentView exportIdenticalCopySelected];
+}
+
 - (void)shareCopyForDocumentViewTag:(NSNumber *)tag rect:(NSDictionary *)rect withFlattening:(BOOL)flattening
 {
     RNTPTDocumentView *documentView = self.documentViews[tag];

--- a/ios/RNTPTDocumentViewModule.m
+++ b/ios/RNTPTDocumentViewModule.m
@@ -964,8 +964,14 @@ RCT_REMAP_METHOD(shareCopy,
                  rejector:(RCTPromiseRejectBlock)reject)
 {
     @try {
-        [[self documentViewManager] shareCopyForDocumentViewTag:tag rect:rect withFlattening:flattening];
-        resolve(nil);
+        if (flattening) {
+            [[self documentViewManager] shareCopyForDocumentViewTag:tag rect:rect withFlattening:flattening];
+            resolve(nil);
+        } else {
+            [[self documentViewManager] shareCopyForDocumentViewTag:tag rect:rect withFlattening:flattening];
+            [[self documentViewManager] exportIdenticalCopySelected:tag];
+            resolve(nil);
+        }
     }
     @catch (NSException *exception) {
         reject(@"share_copy", @"Failed to share a copy", [self errorFromException:exception]);

--- a/ios/RNTPTDocumentViewModule.m
+++ b/ios/RNTPTDocumentViewModule.m
@@ -970,7 +970,7 @@ RCT_REMAP_METHOD(shareCopy,
         } else {
             [[self documentViewManager] shareCopyForDocumentViewTag:tag rect:rect withFlattening:flattening];
             // Prevents crash on iPad/iOS26
-            [NSThread sleepForTimeInterval:1];
+            [NSThread sleepForTimeInterval:5];
             [[self documentViewManager] exportIdenticalCopySelected:tag];
             resolve(nil);
         }

--- a/ios/RNTPTDocumentViewModule.m
+++ b/ios/RNTPTDocumentViewModule.m
@@ -969,6 +969,8 @@ RCT_REMAP_METHOD(shareCopy,
             resolve(nil);
         } else {
             [[self documentViewManager] shareCopyForDocumentViewTag:tag rect:rect withFlattening:flattening];
+            // Prevents crash on iPad/iOS26
+            [NSThread sleepForTimeInterval:1];
             [[self documentViewManager] exportIdenticalCopySelected:tag];
             resolve(nil);
         }


### PR DESCRIPTION
Calling 
```
            [[self documentViewManager] shareCopyForDocumentViewTag:tag rect:rect withFlattening:flattening];
            [[self documentViewManager] exportIdenticalCopySelected:tag];
```
Triggers similar thing as if we shared document somewhere
that way, with next call we can properly export annotations 🚀 